### PR TITLE
last set of jitter changes

### DIFF
--- a/R/build_all_metrics.R
+++ b/R/build_all_metrics.R
@@ -241,15 +241,18 @@ build_all_metrics <- function(
 
   referral_attr_id_organization <- define_var_attribute(data = tbl_referral_organization
                                                         ,population_member_id = 'id_referral_visit'
-                                                        ,value = 'id_organization')
+                                                        ,value = 'id_organization'
+                                                        ,jitter = FALSE)
 
   referral_attr_child_count <- define_var_attribute(tbl_person_child_record_count
                                                     ,'id_referral_visit'
-                                                    ,'child_count_attr')
+                                                    ,'child_count_attr'
+                                                    ,jitter = jitter)
 
   referral_visit_attendance <- define_var_attribute(tbl_visit_reports
                                                     ,'id_referral_visit'
-                                                    ,'visitation_attended')
+                                                    ,'visitation_attended'
+                                                    ,jitter = jitter)
 
   ## Define Events
 

--- a/R/define_var_attribute.R
+++ b/R/define_var_attribute.R
@@ -3,8 +3,15 @@
 
 define_var_attribute <- function(data
                                ,population_member_id
-                               ,value){
-  
+                               ,value
+                               ,jitter = Sys.getenv("OLIVER_REPLICA_JITTER")){
+
+  data = tbl_person_child_record_count
+  population_member_id = 'id_referral_visit'
+  value = 'child_count_attr'
+
+  mean_value <- lapply(data[,value], mean, na.rm = TRUE)
+
   dots <- setNames(list(lazyeval::interp(~ x
                                ,x = as.name(value)))
                    ,value)
@@ -15,5 +22,21 @@ define_var_attribute <- function(data
     mutate_(.
             ,.dots = dots) %>%
     rename_(., .dots = setNames(value, "attr_values"))
+
+  if (lapply(data[,value], class) == 'logical') {
+
+    attribute <- attribute %>%
+      mutate(attr_values = if(jitter){runif(n())} else attr_values
+             ,attr_values = ifelse(attr_values > mean_value, TRUE, FALSE))
+
+  } else if (any(lapply(data[,value], class) == 'integer'
+                     ,lapply(data[,value], class) == 'double')) {
+    attribute <- attribute %>%
+      mutate(attr_values = if(jitter){attr_values + rbinom(n = n()
+                                                           ,size = round(as.numeric(mean_value), digits = 0)
+                                                           ,prob = runif(1))} else attr_values)
+  }
+
   return(attribute)
+
 }

--- a/R/define_var_attribute.R
+++ b/R/define_var_attribute.R
@@ -6,9 +6,9 @@ define_var_attribute <- function(data
                                ,value
                                ,jitter = Sys.getenv("OLIVER_REPLICA_JITTER")){
 
-  data = tbl_person_child_record_count
-  population_member_id = 'id_referral_visit'
-  value = 'child_count_attr'
+  # need to force the data object into a data frame so I can play with it in matrix notation
+  # in the lapply call below
+  data <- data %>% as_data_frame()
 
   mean_value <- lapply(data[,value], mean, na.rm = TRUE)
 


### PR DESCRIPTION
this (and the last merge) have modified the `define_var_period` and `define_var_attr` functions such that they are now capable of jittering (with a jitter param set to TRUE of FALSE). An additional param has also been added to `build_all_metrics` which is passed to these two functions during the build procedure. 

All of the functions will now look for an environment variable called `OLIVER_REPLICA_JITTER` and will fail if the env variable has not been specified *or* if the jitter param has not been set manually (e.g. `define_var_attr(..., jitter = TRUE)`)