### PR TITLE
Add sha and time stamp keys to JSON output

### DIFF
--- a/R/create_measurement_dimension_set.R
+++ b/R/create_measurement_dimension_set.R
@@ -165,6 +165,8 @@ create_measurement_dimension_set <- function(mpp_group = NA
                                               ,sub_value)
                            ,threshold = FALSE
                            ,template = 'default'
+                           ,calc_date = measurement_list[[characteristic_summary_obj]]$calc_date
+                           ,calc_sha = measurement_list[[characteristic_summary_obj]]$calc_sha
   )
 
   return(dimensions)

--- a/R/get_sha_info.R
+++ b/R/get_sha_info.R
@@ -1,9 +1,9 @@
 get_sha_info <- function(){
-  sha_file <- tryCatch(paste0(readLines("R/install-packages.R"), collapse = "")
+  sha_file <- tryCatch(paste0(readLines("/app/R/install-packages.R"), collapse = "")
                        ,warning=function(w) 1)
   if(sha_file==1) {
     sha_value <- 'SHA information not available'
   } else
-    sha_value <- stringr::str_extract(sha_file, stringr::regex('(?<=oliveR@).*(?=\\\\")', multiline = TRUE))
+    sha_value <- stringr::str_extract(sha_file, stringr::regex('(?<=oliveR@).*(?=\\")', multiline = TRUE))
   return(sha_value)
 }

--- a/R/get_sha_info.R
+++ b/R/get_sha_info.R
@@ -1,0 +1,9 @@
+get_sha_info <- function(){
+  sha_file <- tryCatch(paste0(readLines("R/install-packages.R"), collapse = "")
+                       ,warning=function(w) 1)
+  if(sha_file==1) {
+    sha_value <- 'SHA information not available'
+  } else
+    sha_value <- stringr::str_extract(sha_file, stringr::regex('(?<=oliveR@).*(?=\\\\")', multiline = TRUE))
+  return(sha_value)
+}

--- a/R/measurement_single_value_class.R
+++ b/R/measurement_single_value_class.R
@@ -36,6 +36,8 @@ measurement_single_value <- R6Class("measurement_single_value",
           ,data_out_type = NULL
           ,summary_function = NULL
           ,na_rm = NULL
+          ,calc_date = NULL
+          ,calc_sha = NULL
           ,initialize = function(metric_key = NA
                                  ,group_key = 'id_organization'
                                  ,measurement_name = NA
@@ -48,7 +50,9 @@ measurement_single_value <- R6Class("measurement_single_value",
                                  ,rename_var = NA
                                  ,data_out_type = NA
                                  ,summary_function = 'mean'
-                                 ,na_rm = TRUE) {
+                                 ,na_rm = TRUE
+                                 ,calc_date = NA
+                                 ,calc_sha = NA) {
             self$metric_key <- metric_key
             self$group_key <- group_key
             self$measurement_name <- measurement_name
@@ -70,6 +74,8 @@ measurement_single_value <- R6Class("measurement_single_value",
                                                 ,data_out_type = self$data_out_type
                                                 ,summary_function = self$summary_function
                                                 ,na_rm = self$na_rm)
+            self$calc_date <- lubridate::today()
+            self$calc_sha <- get_sha_info()
           }
           ,get_value = function(group_id) {
             filter_criteria <- interp(~ which_column == group_id


### PR DESCRIPTION
These commits implement several changes to provide 2 new keys to the output of `get_metric_list()`: `calc_date`, and `calc_sha`. 

- `calc_date` will provide a timestamp (via `lubridate::today()`) indicating the time that a measurement object was initialized (e.g. via `build_all_metrics()`).
- `calc_sha` will provide any text within `/app/R/install-packages.R` which matches the following REGEX expression: `(?<=oliveR@).*(?=\\")`. In principle, this should only be the SHA listed in the `install-packages.R` script within the [oliver-metrics-api](https://github.com/pocdata/oliver-metrics-api) image. If this script does not exist in a given environment (e.g. due to running oliveR locally), the key should return `'SHA information not available'`.